### PR TITLE
fix: only add a final line separator when the previous line doesn't end with one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ fabric.properties
 .idea/httpRequests
 composer.phar
 /vendor/
+composer.lock

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -4,8 +4,6 @@ namespace Everyday\QuillDelta;
 
 use JetBrains\PhpStorm\Pure;
 
-const LINE_SEPARATOR = "\n";
-
 class Builder
 {
     private array $ops = [];
@@ -29,14 +27,14 @@ class Builder
 
     public function line(array $attributes = []): self
     {
-        return $this->push(DeltaOp::text(LINE_SEPARATOR, $attributes));
+        return $this->push(DeltaOp::text(Delta::LINE_SEPARATOR, $attributes));
     }
 
     #[Pure]
     public function build(): Delta
     {
         $last = end($this->ops);
-        if (!$last || $last->getInsert() !== LINE_SEPARATOR) {
+        if (!$last || $last->getInsert() !== Delta::LINE_SEPARATOR) {
             $this->line();
         }
 

--- a/src/Delta.php
+++ b/src/Delta.php
@@ -12,6 +12,8 @@ class Delta implements \JsonSerializable
      */
     private array $ops;
 
+    public const LINE_SEPARATOR = "\n";
+
     /**
      * @param DeltaOp[] $ops
      */
@@ -155,12 +157,12 @@ class Delta implements \JsonSerializable
         // A valid delta must **ALWAYS** end in a new line
         $last = end($this->ops);
 
-        if ($last !== false && $last->getInsert() !== LINE_SEPARATOR) {
-            if (str_ends_with($last->getInsert(), LINE_SEPARATOR)) {
+        if ($last !== false && $last->getInsert() !== static::LINE_SEPARATOR) {
+            if (str_ends_with($last->getInsert(), static::LINE_SEPARATOR)) {
                 $last->setInsert(substr($last->getInsert(), 0, -1));
             }
 
-            $this->ops[] = DeltaOp::text(LINE_SEPARATOR);
+            $this->ops[] = DeltaOp::text(static::LINE_SEPARATOR);
         }
     }
 }

--- a/src/Delta.php
+++ b/src/Delta.php
@@ -157,12 +157,12 @@ class Delta implements \JsonSerializable
         // A valid delta must **ALWAYS** end in a new line
         $last = end($this->ops);
 
-        if ($last !== false && $last->getInsert() !== static::LINE_SEPARATOR) {
-            if (str_ends_with($last->getInsert(), static::LINE_SEPARATOR)) {
+        if ($last !== false && $last->getInsert() !== self::LINE_SEPARATOR) {
+            if (str_ends_with($last->getInsert(), self::LINE_SEPARATOR)) {
                 $last->setInsert(substr($last->getInsert(), 0, -1));
             }
 
-            $this->ops[] = DeltaOp::text(static::LINE_SEPARATOR);
+            $this->ops[] = DeltaOp::text(self::LINE_SEPARATOR);
         }
     }
 }


### PR DESCRIPTION
Currently, a new line is always added when a quill ops array doesn't end with a new line. The Delta should take into account that the previous line may already be ending with a new line, and shouldn't be appending another one. Instead, it should be removing the previous one and only then adding a new one.